### PR TITLE
Add .gitignore for basic web project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Ignore node dependencies
+node_modules/
+
+# OS metadata
+.DS_Store
+
+# Log files
+*.log
+
+# Editor swap files
+*~
+*.swp
+*.swo
+*.swn


### PR DESCRIPTION
## Summary
- add a standard `.gitignore` for node-based web projects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68523a578f98832c8ea8ab718b74b14d